### PR TITLE
Cleaned up MoonPhasePresenter.java and some minor refactoring.

### DIFF
--- a/src/main/java/interface_adapter/moon_phase/MoonPhasePresenter.java
+++ b/src/main/java/interface_adapter/moon_phase/MoonPhasePresenter.java
@@ -1,27 +1,17 @@
 package interface_adapter.moon_phase;
 
-import entity.MoonPhase;
 import use_case.moon_phase.MoonPhaseOutputBoundary;
 import use_case.moon_phase.MoonPhaseOutputData;
-import view.DisplayMoonPhaseView;
 import view.ViewManager;
-
-import java.io.IOException;
 
 public class MoonPhasePresenter implements MoonPhaseOutputBoundary {
     private ViewManager viewManager;
-    private DisplayMoonPhaseView displayMoonPhaseView;
 
     public MoonPhasePresenter(ViewManager viewManager){
         this.viewManager = viewManager;
     }
 
-    public void setDisplayMoonPhaseView(DisplayMoonPhaseView displayMoonPhaseView){
-        this.displayMoonPhaseView = displayMoonPhaseView;
-    }
-
-    public void displayMoonPhase(MoonPhaseOutputData moonPhaseOutputData) throws IOException {
-
+    public void displayMoonPhase(MoonPhaseOutputData moonPhaseOutputData) {
         viewManager.displayMoonPhase(moonPhaseOutputData);
     }
 
@@ -30,6 +20,6 @@ public class MoonPhasePresenter implements MoonPhaseOutputBoundary {
     }
 
     public void prepareFailView(String errorMessage) {
-        viewManager.show(errorMessage);
+        viewManager.showFailView(errorMessage);
     }
 }


### PR DESCRIPTION
MoonPhasePresenter now uses failView from ViewManager.java to display error messages and does not directly interact with DisplayMoonPhaseView, adhering more to Clean Architecture's Dependency Rule.